### PR TITLE
Adding DisplayName option property

### DIFF
--- a/src/MongoDB.Driver.Core.Extensions.OpenTelemetry/Implementation/CommandListener.cs
+++ b/src/MongoDB.Driver.Core.Extensions.OpenTelemetry/Implementation/CommandListener.cs
@@ -34,19 +34,26 @@ namespace MongoDB.Driver.Core.Extensions.OpenTelemetry.Implementation
             {
                 activity.AddTag("db.type", "mongo");
                 activity.AddTag("db.instance", message.DatabaseNamespace.DatabaseName);
-                var endPoint = message.ConnectionId?.ServerId?.EndPoint;
-                switch (endPoint)
+                if (string.IsNullOrWhiteSpace(_options.DisplayName))
                 {
-                    case IPEndPoint ipEndPoint:
-                        activity.AddTag("db.user", $"mongodb://{ipEndPoint.Address}:{ipEndPoint.Port}");
-                        activity.AddTag("net.peer.ip", ipEndPoint.Address.ToString());
-                        activity.AddTag("net.peer.port", ipEndPoint.Port.ToString());
-                        break;
-                    case DnsEndPoint dnsEndPoint:
-                        activity.AddTag("db.user", $"mongodb://{dnsEndPoint.Host}:{dnsEndPoint.Port}");
-                        activity.AddTag("net.peer.name", dnsEndPoint.Host);
-                        activity.AddTag("net.peer.port", dnsEndPoint.Port.ToString());
-                        break;
+                    var endPoint = message.ConnectionId?.ServerId?.EndPoint;
+                    switch (endPoint)
+                    {
+                        case IPEndPoint ipEndPoint:
+                            activity.AddTag("db.user", $"mongodb://{ipEndPoint.Address}:{ipEndPoint.Port}");
+                            activity.AddTag("net.peer.ip", ipEndPoint.Address.ToString());
+                            activity.AddTag("net.peer.port", ipEndPoint.Port.ToString());
+                            break;
+                        case DnsEndPoint dnsEndPoint:
+                            activity.AddTag("db.user", $"mongodb://{dnsEndPoint.Host}:{dnsEndPoint.Port}");
+                            activity.AddTag("net.peer.name", dnsEndPoint.Host);
+                            activity.AddTag("net.peer.port", dnsEndPoint.Port.ToString());
+                            break;
+                    }
+                }
+                else
+                {
+                    activity.AddTag("net.peer.name", _options.DisplayName);
                 }
 
                 if (_options.CaptureCommandText)

--- a/src/MongoDB.Driver.Core.Extensions.OpenTelemetry/MongoDBInstrumentationOptions.cs
+++ b/src/MongoDB.Driver.Core.Extensions.OpenTelemetry/MongoDBInstrumentationOptions.cs
@@ -3,5 +3,6 @@
     public class MongoDBInstrumentationOptions
     {
         public bool CaptureCommandText { get; set; }
+        public string DisplayName { get; set; }
     }
 }


### PR DESCRIPTION
Sometime I don't need to know the details about specific MongoDb connection and port as they may be long and dynamically generated. Instead I would just prefer to have a clean name in the trace like "Api_Mongo" or "Identity_Mongo" to differentiate between the services in a trace. If the option is set, then it would be added as the "net.peer.name" instead of the actual mongo server address and would be displayed as the caption for the spans by the tracing UIs.